### PR TITLE
Class context fix for await/awaitAll

### DIFF
--- a/promise_server.js
+++ b/promise_server.js
@@ -32,11 +32,11 @@ exports.makeCompatible = function (Promise, Fiber) {
   Promise.prototype.then = meteorPromiseThen;
 
   Promise.awaitAll = function (args) {
-    return awaitPromise(this.all(args));
+    return awaitPromise(Promise.all(args));
   };
 
   Promise.await = function (arg) {
-    return awaitPromise(this.resolve(arg));
+    return awaitPromise(Promise.resolve(arg));
   };
 
   Promise.prototype.await = function () {


### PR DESCRIPTION
I was trying to use `makeCompatible` to add Meteor support to the bluebird
promises library, like this:

    const Promise = require( 'bluebird' );
    const Fiber = require( 'fibers' );
    require( 'meteor-promise' ).makeCompatible( Promise, Fiber );

This didn't work correctly and resulted in the error message
`this.resolve is not a function` whenever I attempted to use
`Promise.await` or `Promise.awaitAll`.  I tracked the error down to
the implementation of `await` and `awaitAll` using `this.resolve` and
`this.all`, and apparently assuming that the context would have `this`
set to the promise implementation when that happened.  In my
environment I found this wasn't the case (instead I had `this ===
global`).  By making the small change that is in this PR (simply
replacing `this` with `Promise` in those two class methods) I was able
to get it to work.